### PR TITLE
finish `writeLog` functionality for Firebase

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,8 @@ function writeLog(prompt, response, rating) {
     response,
     rating,
     timestamp: serverTimestamp(),
+  }).catch(error => {
+    console.error('Failed to write log:', error);
   });
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,8 @@ onAuthStateChanged(auth, user => {
 });
 
 function writeLog(prompt, response, rating) {
-  set(ref(database, 'users/' + uid), {
+  const logsRef = ref(database, 'users/' + uid + '/logs');
+  set(logsRef, {
     prompt,
     response,
     rating,

--- a/src/App.js
+++ b/src/App.js
@@ -51,6 +51,7 @@ function writeLog(prompt, response, rating) {
   }).catch(error => {
     console.error('Failed to write log:', error);
   });
+  console.log('Wrote log');
 }
 
 const App = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import ChatView from './components/ChatView';
 
 import { initializeApp } from 'firebase/app';
 import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
-import { getDatabase, ref, set } from 'firebase/database';
+import { getDatabase, ref, push } from 'firebase/database';
 import { serverTimestamp } from 'firebase/firestore';
 
 const firebaseConfig = {
@@ -37,7 +37,7 @@ onAuthStateChanged(auth, user => {
 
 function writeLog(prompt, response, rating) {
   const logsRef = ref(database, 'users/' + uid + '/logs');
-  set(logsRef, {
+  push(logsRef, {
     prompt,
     response,
     rating,

--- a/src/App.js
+++ b/src/App.js
@@ -51,7 +51,6 @@ function writeLog(prompt, response, rating) {
   }).catch(error => {
     console.error('Failed to write log:', error);
   });
-  console.log('Wrote log');
 }
 
 const App = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { initializeApp } from 'firebase/app';
 import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import { getDatabase, ref, push, serverTimestamp } from 'firebase/database';
 
-const firebaseConfig = {
+const firebaseConfigDan = {
   apiKey: 'AIzaSyBhsjVuPP_njleOaq68JRQ3BNbbdzSrMZc',
   authDomain: 'test-4b540.firebaseapp.com',
   projectId: 'test-4b540',
@@ -15,17 +15,24 @@ const firebaseConfig = {
   appId: '1:929535662880:web:9d0f0f019f6b87a8319545',
 };
 
+const firebaseConfig = {
+  apiKey: "AIzaSyCHiv7gPoRZ_LKD-7XfDW1HjpsRlQA816Y",
+  authDomain: "log-chat-gpt.firebaseapp.com",
+  projectId: "log-chat-gpt",
+  storageBucket: "log-chat-gpt.appspot.com",
+  messagingSenderId: "107892481835",
+  appId: "1:107892481835:web:1d42ab7d2c302706892f6e",
+};
+
 const app = initializeApp(firebaseConfig);
-
 const database = getDatabase(app);
-
 const auth = getAuth();
+
+let uid;
 
 signInAnonymously(auth).catch(error => {
   console.error('Failed to sign in anonymously:', error);
 });
-
-let uid;
 
 onAuthStateChanged(auth, user => {
   console.log(user);

--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,7 @@ import ChatView from './components/ChatView';
 
 import { initializeApp } from 'firebase/app';
 import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
-import { getDatabase, ref, push } from 'firebase/database';
-import { serverTimestamp } from 'firebase/firestore';
+import { getDatabase, ref, push, serverTimestamp } from 'firebase/database';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyBhsjVuPP_njleOaq68JRQ3BNbbdzSrMZc',

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,9 @@ const database = getDatabase(app);
 
 const auth = getAuth();
 
-signInAnonymously(auth);
+signInAnonymously(auth).catch(error => {
+  console.error('Failed to sign in anonymously:', error);
+});
 
 let uid;
 

--- a/src/components/ChatView.js
+++ b/src/components/ChatView.js
@@ -9,7 +9,7 @@ import { davinci } from '../utils/davinci';
 /**
  * A chat view component that displays a list of messages and a form for sending new messages.
  */
-const ChatView = writeLog => {
+const ChatView = ({ writeLog }) => {
   const messagesEndRef = useRef();
   const inputRef = useRef();
   const [formValue, setFormValue] = useState('');


### PR DESCRIPTION
[here](https://github.com/danmogil/chatgpt-clone/assets/44552816/d6d505f2-45c4-4845-8185-18540d33e5fb) is a demo.

- fixed bug in `ChatView` component where `writeLog` function was being passed as object instead of prop.
- changed import of `serverTimestamp` from Firestore to Realtime Database
- changed logging method from `set` to `push`
- added error catching